### PR TITLE
feat(LEO-528): Allow multiple IAB categories in video metadata

### DIFF
--- a/dev-docs/bidders/dailymotion.md
+++ b/dev-docs/bidders/dailymotion.md
@@ -72,7 +72,7 @@ const adUnits = [
         api: [2,7],
         description: 'this is a video description',
         duration: 556,
-        iabcat2: 'test_cat',
+        iabcat2: ['6', '17'],
         id: '54321',
         lang: 'FR',
         private: false,
@@ -88,7 +88,7 @@ const adUnits = [
         video: {
           description: 'this is a test video description',
           duration: 330,
-          iabcat2: 'test_cat',
+          iabcat2: ['6', '17'],
           id: '54321',
           lang: 'FR',
           private: false,
@@ -107,11 +107,11 @@ Following video metadata fields can be added in mediaTypes.video or bids.params.
 
 * `description` - Video description
 * `duration` - Video duration in seconds
-* `iabcat2` - Video IAB category
+* `iabcat2` - List of IAB category IDs from the [2.0 taxonomy](https://github.com/InteractiveAdvertisingBureau/Taxonomies/blob/main/Content%20Taxonomies/Content%20Taxonomy%202.0.tsv)
 * `id` - Video unique ID in host video infrastructure
 * `lang` - ISO 639-1 code for main language used in the video
 * `private` - True if video is not publicly available
 * `tags` - Tags for the video, comma separated
 * `title` - Video title
 * `topics` - Main topics for the video, comma separated
-* `xid` - Dailymotion video identifier (only applicable if using the Dailymotion player) and allows better targeting
+* `xid` - Dailymotion video identifier (only applicable if using the Dailymotion player), allows better targeting


### PR DESCRIPTION
The same way as we can have an array of IAB categories level 1 in the ORTB request, this PR introduces an array for the IAB categories level 2.

To be forward compatible with level [2.2](https://github.com/InteractiveAdvertisingBureau/Taxonomies/blob/main/Content%20Taxonomies/Content%20Taxonomy%202.2.tsv) and [3.0](https://github.com/InteractiveAdvertisingBureau/Taxonomies/blob/main/Content%20Taxonomies/Content%20Taxonomy%203.0.tsv) specifications, the category IDs should be sent as strings.