### PR TITLE
Dailymotion Bid Adapter: Exclude non standard fields from mediaTypes.video

### DIFF
--- a/dev-docs/bidders/dailymotion.md
+++ b/dev-docs/bidders/dailymotion.md
@@ -59,7 +59,7 @@ const adUnits = [
     bids: [{
       bidder: 'dailymotion',
       params: {
-        apiKey: 'dailymotion-testing'
+        apiKey: 'dailymotion-testing',
       },
     }],
     code: 'test-ad-unit',
@@ -87,7 +87,10 @@ const adUnits = [
     bids: [{
       bidder: 'dailymotion',
       params: {
-        apiKey: 'dailymotion-testing'
+        apiKey: 'dailymotion-testing',
+        video: {
+          xid: 'x123456'     // Dailymotion infrastructure unique video ID
+        },
       }
     }],
     code: 'test-ad-unit',
@@ -98,7 +101,6 @@ const adUnits = [
         startdelay: 0,
         w: 1280,
         h: 720,
-        xid: 'x123456'     // Dailymotion infrastructure unique video ID
       },
     }
   }
@@ -118,7 +120,17 @@ const adUnits = [
       params: {
         apiKey: 'dailymotion-testing',
         video: {
-          description: 'overriden video description'
+          description: 'this is a video description',
+          duration: 556,
+          iabcat1: ['IAB-2'],
+          iabcat2: ['6', '17'],
+          id: '54321',
+          lang: 'FR',
+          livestream: 0,
+          private: false,
+          tags: 'tag_1,tag_2,tag_3',
+          title: 'test video',
+          topics: 'topic_1, topic_2',
         }
       }
     }],
@@ -127,18 +139,7 @@ const adUnits = [
       video: {
         api: [2, 7],
         context: 'instream',
-        description: 'this is a video description',
-        duration: 556,
-        iabcat1: ['IAB-2'],
-        iabcat2: ['6', '17'],
-        id: '54321',
-        lang: 'FR',
-        livestream: 0,
-        private: false,
         startdelay: 0,
-        tags: 'tag_1,tag_2,tag_3',
-        title: 'test video',
-        topics: 'topic_1, topic_2',
         w: 1280,
         h: 720,
       },
@@ -147,8 +148,7 @@ const adUnits = [
 ];
 ```
 
-Each of the following video metadata fields can be added in mediaTypes.video or bids.params.video.
-If a field exists in both places, it will be overridden by bids.params.video.
+Each of the following video metadata fields can be added in bids.params.video.
 
 * `description` - Video description
 * `duration` - Video duration in seconds
@@ -165,12 +165,12 @@ If a field exists in both places, it will be overridden by bids.params.video.
 
 If you already specify [First-Party data](https://docs.prebid.org/features/firstPartyData.html) through the `ortb2` object when calling [`pbjs.requestBids(requestObj)`](https://docs.prebid.org/dev-docs/publisher-api-reference/requestBids.html), we will fallback to those values when possible. See the mapping below.
 
-| From ortb2                                                          | Metadata fields |
-|---------------------------------------------------------------------|-----------------|
-| `ortb2.site.content.data` where `ext.segtax` is `4`                 | `iabcat1`       |
-| `ortb2.site.content.data`  where  `ext.segtax`  is  `5`, `6` or `7` | `iabcat2`       |
-| `ortb2.site.content.id`                                             | `id`            |
-| `ortb2.site.content.language`                                       | `lang`          |
-| `ortb2.site.content.livestream`                                     | `livestream`    |
-| `ortb2.site.content.keywords`                                       | `tags`          |
-| `ortb2.site.content.title`                                          | `title`         |
+| From ortb2                                                                      | Metadata fields |
+|---------------------------------------------------------------------------------|-----------------|
+| `ortb2.site.content.cat` OR `ortb2.site.content.data` where `ext.segtax` is `4` | `iabcat1`       |
+| `ortb2.site.content.data` where `ext.segtax` is `5`, `6` or `7`                 | `iabcat2`       |
+| `ortb2.site.content.id`                                                         | `id`            |
+| `ortb2.site.content.language`                                                   | `lang`          |
+| `ortb2.site.content.livestream`                                                 | `livestream`    |
+| `ortb2.site.content.keywords`                                                   | `tags`          |
+| `ortb2.site.content.title`                                                      | `title`         |


### PR DESCRIPTION
## 🏷 Type of documentation

- [x] update bid adapter
- [x] new examples

## 📋 Checklist

- [x] Related pull requests in prebid.js or server are linked -> https://github.com/prebid/Prebid.js/pull/11366

We have excluded all fields from `mediaTypes.video` that are non standard. See https://github.com/prebid/Prebid.js/pull/11366#discussion_r1572917634